### PR TITLE
[et-driver] Fix version on dkms build.

### DIFF
--- a/et-driver/Makefile
+++ b/et-driver/Makefile
@@ -1,8 +1,8 @@
 MODULE_DIR := $(CURDIR)
 KDIR := /lib/modules/$(shell uname -r)/build
 KMAKE := $(MAKE) -C $(KDIR) M=$(MODULE_DIR)
-ET_MODULE_VERSION=$(shell cat VERSION)
-CFLAGS_MODULE+=-DET_MODULE_VERSION=\"$(ET_MODULE_VERSION=)\"
+ET_MODULE_VERSION := $(or $(shell cat VERSION 2>/dev/null), $(shell cat $(src)/VERSION 2>/dev/null), unknown)
+CFLAGS_MODULE+=-DET_MODULE_VERSION=\"$(ET_MODULE_VERSION)\"
 #subdir-ccflags-y += -I$(src)/include
 
 obj-m += et-soc1.o


### PR DESCRIPTION
DKMS builds in the kbuild directory.

We should move towards generating dkms.conf and a version header, but for now this fixes things.

When version is empty, devicelayer fails to open the device as cannot check the compatibility of the driver.