### PR TITLE
CMakeLists.txt: do not build GUI on easy profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ file(COPY et-driver/et_ioctl.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 # External dependencies
 ThirdParty(g3log https://github.com/KjellKod/g3log v1.1-408-g38dbddc "-DUSE_DYNAMIC_LOGGING_LEVELS=ON -DADD_G3LOG_UNIT_TEST=OFF -DINSTALL_G3LOG=ON")
-ThirdParty(easy_profiler https://github.com/yse/easy_profiler.git v2.1.0-66-gcc0e154 "")
+ThirdParty(easy_profiler https://github.com/yse/easy_profiler.git v2.1.0-66-gcc0e154 "-DEASY_PROFILER_NO_GUI=ON")
 ThirdParty(cereal https://github.com/USCiLab/cereal.git v1.3.2 "-DJUST_INSTALL_CEREAL=ON")
 
 #


### PR DESCRIPTION
We're using an old version of easy_profiler. The QT libraries are hard to find and might cause issues on systems that do have a newer QT installed. Disable it for now.

Plan is to update easy_profiler and make the gui (very useful) optional.