### PR TITLE
[et-common-libs] cstdbool was removed in C++20

### DIFF
--- a/et-common-libs/include/etsoc/isa/tensors.h
+++ b/et-common-libs/include/etsoc/isa/tensors.h
@@ -18,7 +18,9 @@ extern "C" {
 
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
 #include <cinttypes>
+#if (__cplusplus < 202002L)
 #include <cstdbool>
+#endif
 #else
 #include <inttypes.h>
 #include <stdbool.h>


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/header/cstdbool.html
