### PR TITLE
[device-management-application] Bump bundled FTXUI library and resolve breaking API change.

### DIFF
--- a/device-management-application/CMakeLists.txt
+++ b/device-management-application/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
   
   FetchContent_Declare(ftxui
     GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-    GIT_TAG v5.0.0
+    GIT_TAG v6.1.9
   )
   
   FetchContent_GetProperties(ftxui)

--- a/device-management-application/include/render.hpp
+++ b/device-management-application/include/render.hpp
@@ -81,7 +81,7 @@ public:
   ExitComponent(ScreenInteractive& screen)
     : screen_(screen) {
   }
-  Element Render() override {
+  Element OnRender() override {
     screen_.ExitLoopClosure()();
     return text("");
   }


### PR DESCRIPTION
Bump to current FTXUI release and address breaking API change denoted here:
https://github.com/ArthurSonzogni/FTXUI/issues/1049
https://github.com/ArthurSonzogni/FTXUI/commit/b0e087ecefbdb8ef4cb0f6a5335e9a731c3c707c
