### PR TITLE
[device-management-application] Bring in fmt/ranges.h for fmt::join calls.

### DIFF
--- a/device-management-application/src/dev_mngt_service.cc
+++ b/device-management-application/src/dev_mngt_service.cc
@@ -30,6 +30,7 @@ namespace filesystem = std::experimental::filesystem;
 
 #include <fcntl.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <fstream>
 #include <getopt.h>
 #include <glog/logging.h>


### PR DESCRIPTION
Support building with current fmtlib versions (eg, 12.x) as fmt/ranges.h is not implicitly included any more.

I have tested that it also works with the older fmtlib (9.1.0) included in Ubuntu 24.04.