### PR TITLE
Add Docker support with Dockerfile and docker-compose.yaml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,77 @@
+# Git files
+.gitignore
+.gitattributes
+.gitmodules
+
+# Build directories
+build/
+build-*/
+**/build/
+*.o
+*.a
+*.so
+*.dylib
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Documentation build artifacts
+doc/_build/
+docs/_build/
+*.pdf
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.tox/
+
+# Conan cache
+.conan/
+conan.lock
+
+# CMake cache
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+
+# Test and coverage reports
+*.gcov
+*.gcda
+*.gcno
+coverage/
+htmlcov/
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.bak
+*.orig
+.backup/
+
+# Docker files (don't copy into container)
+Dockerfile
+docker-compose.yaml
+.dockerignore
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+Jenkinsfile
+
+# Package files
+*.tar.gz
+*.zip
+*.deb
+*.rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,118 @@
+# ET Platform Docker Build Environment
+# This Dockerfile creates a complete build environment for the ET Platform
+# including the RISC-V GNU toolchain and all necessary dependencies.
+
+FROM ubuntu:24.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set up the installation directory
+ENV ET_INSTALL_DIR=/opt/et
+ENV PATH="${ET_INSTALL_DIR}/bin:${PATH}"
+
+# Install base dependencies for RISC-V toolchain
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    autotools-dev \
+    curl \
+    python3 \
+    python3-pip \
+    python3-tomli \
+    libmpc-dev \
+    libmpfr-dev \
+    libgmp-dev \
+    gawk \
+    build-essential \
+    bison \
+    flex \
+    texinfo \
+    gperf \
+    libtool \
+    patchutils \
+    bc \
+    zlib1g-dev \
+    libexpat-dev \
+    dos2unix \
+    ninja-build \
+    git \
+    cmake \
+    libglib2.0-dev \
+    libslirp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ET Platform build dependencies
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libjson-c-dev \
+    libgtest-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libgmock-dev \
+    lz4 \
+    liblz4-dev \
+    libboost-all-dev \
+    libcap-dev \
+    libcap2-bin \
+    doxygen \
+    graphviz \
+    nlohmann-json3-dev \
+    python3-sphinx \
+    python3-sphinx-rtd-theme \
+    python3-breathe \
+    python3-jsonschema \
+    libfmt-dev \
+    xxd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create the ET install directory
+RUN mkdir -p ${ET_INSTALL_DIR} && chmod 755 ${ET_INSTALL_DIR}
+
+# Build and install the RISC-V GNU Toolchain
+WORKDIR /tmp/toolchain
+RUN git clone https://github.com/aifoundry-org/riscv-gnu-toolchain && \
+    cd riscv-gnu-toolchain && \
+    ./configure \
+        --prefix=${ET_INSTALL_DIR} \
+        --with-arch=rv64imfc \
+        --with-abi=lp64f \
+        --with-languages=c,c++ \
+        --with-cmodel=medany && \
+    make -j$(nproc) && \
+    cd /tmp && \
+    rm -rf /tmp/toolchain
+
+# Set working directory for the ET Platform source
+WORKDIR /workspace
+
+# Copy the ET Platform source code
+COPY . /workspace/
+
+# Normalize line endings for scripts copied from Windows hosts
+RUN find /workspace -type f -name '*.py' -exec dos2unix {} +
+
+# Create build directory
+RUN mkdir -p /workspace/build
+
+# Configure the build
+WORKDIR /workspace/build
+RUN cmake \
+    -DTOOLCHAIN_DIR=${ET_INSTALL_DIR} \
+    -DCMAKE_INSTALL_PREFIX=${ET_INSTALL_DIR} \
+    ..
+
+# Build the ET Platform (use ARG to allow override)
+ARG BUILD_JOBS=4
+RUN make -j${BUILD_JOBS}
+
+# Set the default working directory
+WORKDIR /workspace
+
+# Default command: run a shell
+CMD ["/bin/bash"]
+
+# Labels for metadata
+LABEL maintainer="ET Platform Team"
+LABEL description="ET Platform Build Environment with RISC-V Toolchain"
+LABEL version="1.0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,109 @@
+version: '3.8'
+
+services:
+  # ET Platform build environment
+  et-platform:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Number of parallel build jobs (adjust based on your system)
+        BUILD_JOBS: 8
+    image: et-platform:latest
+    container_name: et-platform-builder
+    
+    # Mount the source code as a volume for development
+    volumes:
+      # Mount source code (read-only in production, read-write for development)
+      - ./:/workspace:rw
+      # Persist build artifacts
+      - et-build-cache:/workspace/build
+      # Persist installed binaries
+      - et-install:/opt/et
+    
+    # Set environment variables
+    environment:
+      - ET_INSTALL_DIR=/opt/et
+      - CMAKE_BUILD_TYPE=Release
+    
+    # Keep container running for interactive use
+    stdin_open: true
+    tty: true
+    
+    # Resource limits (adjust based on your needs)
+    deploy:
+      resources:
+        limits:
+          cpus: '8'
+          memory: 16G
+        reservations:
+          cpus: '4'
+          memory: 8G
+    
+    # Network configuration
+    networks:
+      - et-network
+    
+    # Healthcheck to verify the environment is ready
+    healthcheck:
+      test: ["CMD", "test", "-f", "/opt/et/bin/riscv64-unknown-elf-gcc"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Optional: Development container with mounted source
+  et-platform-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        BUILD_JOBS: 8
+      # Cache build layers for faster rebuilds
+      cache_from:
+        - et-platform:latest
+    image: et-platform-dev:latest
+    container_name: et-platform-dev
+    
+    volumes:
+      # Mount source code for live development
+      - ./:/workspace:rw
+      # Separate build cache for dev
+      - et-dev-build-cache:/workspace/build
+      # Share installed binaries with main container
+      - et-install:/opt/et
+    
+    environment:
+      - ET_INSTALL_DIR=/opt/et
+      - CMAKE_BUILD_TYPE=Debug
+      - ENABLE_WARNINGS_AS_ERRORS=ON
+    
+    stdin_open: true
+    tty: true
+    
+    networks:
+      - et-network
+    
+    # Override command to provide development shell
+    command: /bin/bash
+    
+    profiles:
+      - dev
+
+# Named volumes for persistence
+volumes:
+  et-build-cache:
+    driver: local
+    name: et-platform-build-cache
+  et-dev-build-cache:
+    driver: local
+    name: et-platform-dev-build-cache
+  et-install:
+    driver: local
+    name: et-platform-install
+
+# Network for container communication
+networks:
+  et-network:
+    driver: bridge
+    name: et-platform-network


### PR DESCRIPTION
## Summary
- Add a Dockerfile that provisions the Ubuntu 24.04 build environment, installs ET Platform dependencies, and builds the RISC-V GNU toolchain into `/opt/et` and then builds et-platform
- Introduce a docker-compose stack with dedicated build and dev services, persistent build/install volumes, and a healthcheck to verify the toolchain is available.
- Create a `.dockerignore` tuned for CMake/Conan builds to keep images lean and avoid copying transient artifacts.

## Testing
- `docker compose build`