### PR TITLE
[sw-sysemu] Fix example Makefile by suppressing unsupported .riscv.attributes

### DIFF
--- a/sw-sysemu/examples/common/include.mk
+++ b/sw-sysemu/examples/common/include.mk
@@ -59,7 +59,9 @@ CFLAGS += -Wall \
 	     -mcmodel=medany \
 	     -march=$(MINION_MARCH) \
 	     -mabi=$(MINION_MABI) \
-	     -Wa,-march=$(MINION_MARCH),-mabi=$(MINION_MABI)
+	     -Wa,-march=$(MINION_MARCH),-mabi=$(MINION_MABI) \
+	     -mno-riscv-attribute \
+	     -Wa,-mno-arch-attr
 
 CFLAGS += $(CFLAGS_STDLIB_$(USE_STDLIB))
 


### PR DESCRIPTION
* sw-sysemu/examples/common/include.mk
  (CFLAGS): Add -mno-riscv-attribute and -Wa,-mno-arch-attr

Reported by: Dr. Beau Webber
