### PR TITLE
update Dockerfile to pull down artifacts when available, else build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ The main software components are:
 
 ## How to build ET Platform
 
-### 1. Create install directory
+You can build it locally, or in a docker container.
+
+### Local Build Instructions
+
+#### 1. Create install directory
 
 Start by creating a user writable `/opt/et`.
 
@@ -43,7 +47,7 @@ Start by creating a user writable `/opt/et`.
   $ sudo chown $(whoami) /opt/et
 ```
 
-### 2. Install the ET RISCV GNU Toolchain
+#### 2. Install the ET RISCV GNU Toolchain
 
 The next step is installing the full toolchain for _minions_ (gcc + newlib).
 
@@ -66,7 +70,7 @@ Once all the required libraries are installed, you can proceed to build the tool
 
 This will install `riscv-unknown-elf-gcc` and other toolchain utilities in `/opt/et/bin`
 
-### 3. Build the ET Platform.
+#### 3. Build the ET Platform.
 
 Now that the ET RISCV Toolchain is installed in `/opt/et`, we can proceed to compiling the full ET-Platform.
 
@@ -100,7 +104,7 @@ Then, it is time to fetch and build:
 
 This will compile all the ET-Platform software and install it in `/opt/et`.
 
-### 4. Run a simple test.
+#### 4. Run a simple test.
 
 Try to run a simple test with:
 
@@ -110,3 +114,25 @@ Try to run a simple test with:
 
 This will load and execute kernels on minions, using the software simulator.
 
+### Build in Docker
+
+To build in Docker, just run:
+
+```sh
+$ docker build -t et-platform -f docker/Dockerfile .
+```
+
+You can set the following build arguments via `--build-arg KEY=value`:
+
+- `BASE_DISTRO`: The distro to build on, default is `ubuntu`.
+- `DISTRO_VERSION`: The version of the distro to build. Default is `24.04`.
+- `ET_INSTALL_DIR`: What directory inside the final container to install ET Platform to. Default is `/opt/et`.
+- `FORCE_REBUILD`: Force rebuild of the toolchain, even if a cached version is available. Default is `false`.
+- `ETARCH`: The architecture to build the toolchain for. Default is `rv64imfc`.
+- `ETABI`: The ABI to build the toolchain for. Default is `lp64f`.
+- `BUILD_JOBS`: Number of parallel build jobs. Default is number of host CPU cores.
+
+In addition, you can use docker compose via the [docker-compose.yaml](docker-compose.yaml) file.
+
+**Note:** When building via Docker, whether `docker build` or compose, you **must** execute the command from he
+root of the repository, as the docker context needs to include all the source code.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,49 +2,43 @@
 # This Dockerfile creates a complete build environment for the ET Platform
 # including the RISC-V GNU toolchain and all necessary dependencies.
 
-ARG UBUNTU_VERSION=24.04
-FROM ubuntu:${UBUNTU_VERSION}
+ARG BASE_DISTRO=ubuntu
+ARG DISTRO_VERSION=24.04
+FROM ${BASE_DISTRO}:${DISTRO_VERSION} AS toolchain_builder
+
+ARG DISTRO_VERSION
+ARG BASE_DISTRO
+ARG ET_INSTALL_DIR=/opt/et
+ARG ETARCH=rv64imfc
+ARG ETABI=lp64f
+ARG FORCE_REBUILD=false
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set up the installation directory
-ENV ET_INSTALL_DIR=/opt/et
-ENV PATH="${ET_INSTALL_DIR}/bin:${PATH}"
+ENV ET_INSTALL_DIR=${ET_INSTALL_DIR}
 
-# Install base dependencies for RISC-V toolchain
-RUN apt-get update && apt-get install -y \
-    autoconf \
-    automake \
-    autotools-dev \
-    curl \
-    python3 \
-    python3-pip \
-    python3-tomli \
-    libmpc-dev \
-    libmpfr-dev \
-    libgmp-dev \
-    gawk \
-    build-essential \
-    bison \
-    flex \
-    texinfo \
-    gperf \
-    libtool \
-    patchutils \
-    bc \
-    zlib1g-dev \
-    libexpat-dev \
-    dos2unix \
-    ninja-build \
-    git \
-    cmake \
-    libglib2.0-dev \
-    libslirp-dev \
-    && rm -rf /var/lib/apt/lists/*
+# Create the ET install directory
+RUN mkdir -p ${ET_INSTALL_DIR} && chmod 755 ${ET_INSTALL_DIR}
+
+# Download or build and install the RISC-V GNU Toolchain
+COPY ./docker/get_toolchain.sh /get_toolchain.sh
+RUN DEBUG=1 /get_toolchain.sh --force ${FORCE_REBUILD} --install-deps true --repo aifoundry-org/riscv-gnu-toolchain --install-dir ${ET_INSTALL_DIR} --base-distro ${BASE_DISTRO} --distro-version ${DISTRO_VERSION} --arch ${ETARCH} --abi ${ETABI}
+
+FROM ${BASE_DISTRO}:${DISTRO_VERSION} AS etplatform_builder
+ARG ET_INSTALL_DIR=/opt/et
+
+# Copy the RISC-V GNU Toolchain from the previous stage
+COPY --from=toolchain_builder ${ET_INSTALL_DIR} ${ET_INSTALL_DIR}
 
 # Install ET Platform build dependencies
 RUN apt-get update && apt-get install -y \
+    cmake \
+    dos2unix \
+    gcc \
+    g++ \
+    git \
     pkg-config \
     libjson-c-dev \
     libgtest-dev \
@@ -67,34 +61,17 @@ RUN apt-get update && apt-get install -y \
     xxd \
     && rm -rf /var/lib/apt/lists/*
 
-# Create the ET install directory
-RUN mkdir -p ${ET_INSTALL_DIR} && chmod 755 ${ET_INSTALL_DIR}
-
-# Build and install the RISC-V GNU Toolchain
-WORKDIR /tmp/toolchain
-RUN git clone https://github.com/aifoundry-org/riscv-gnu-toolchain && \
-    cd riscv-gnu-toolchain && \
-    ./configure \
-        --prefix=${ET_INSTALL_DIR} \
-        --with-arch=rv64imfc \
-        --with-abi=lp64f \
-        --with-languages=c,c++ \
-        --with-cmodel=medany && \
-    make -j$(nproc) && \
-    cd /tmp && \
-    rm -rf /tmp/toolchain
-
 # Set working directory for the ET Platform source
 WORKDIR /workspace
 
 # Copy the ET Platform source code
-COPY . /workspace/
+COPY . .
 
 # Normalize line endings for scripts copied from Windows hosts
-RUN find /workspace -type f -name '*.py' -exec dos2unix {} +
+RUN find . -type f -name '*.py' -exec dos2unix {} +
 
 # Create build directory
-RUN mkdir -p /workspace/build
+RUN mkdir -p ./build
 
 # Configure the build
 WORKDIR /workspace/build

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,13 +4,14 @@ services:
   # ET Platform build environment
   et-platform:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: docker/Dockerfile
       args:
         # Ubuntu base image version passed through to the Dockerfile (defaults to Ubuntu 24.04)
-        UBUNTU_VERSION: ${UBUNTU_VERSION:-24.04}
+        BASE_DISTRO: ${BASE_DISTRO:-ubuntu}
+        DISTRO_VERSION: ${DISTRO_VERSION:-24.04}
         # Number of parallel build jobs (adjust based on your system)
-        BUILD_JOBS: 8
+        BUILD_JOBS: ${BUILD_JOBS:-8}
     image: et-platform:latest
     container_name: et-platform-builder
 
@@ -57,12 +58,13 @@ services:
   # Optional: Development container with mounted source
   et-platform-dev:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: docker/Dockerfile
       args:
         # Ubuntu base image version passed through to the Dockerfile (defaults to Ubuntu 24.04)
-        UBUNTU_VERSION: ${UBUNTU_VERSION:-24.04}
-        BUILD_JOBS: 8
+        BASE_DISTRO: ${BASE_DISTRO:-ubuntu}
+        DISTRO_VERSION: ${DISTRO_VERSION:-24.04}
+        BUILD_JOBS: ${BUILD_JOBS:-8}
       # Cache build layers for faster rebuilds
       cache_from:
         - et-platform:latest

--- a/docker/get_toolchain.sh
+++ b/docker/get_toolchain.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -e
+
+[ -n "$DEBUG" ] && set -x
+
+help() {
+    echo "Usage: $0 --repo <repo> --install-dir <install_dir> --base-distro <base_distro> --distro-version <distro_version> --arch <arch> --abi <abi>"
+    echo ""
+    echo "Options:"
+    echo "  --force           Force rebuild even if an existing build is found"
+    echo "  --repo            GitHub repository in the format 'owner/repo' (e.g., 'aifoundry-org/riscv-gnu-toolchain')"
+    echo "  --install-dir     Directory where the toolchain should be installed"
+    echo "  --base-distro     Base distribution (e.g., 'ubuntu', 'debian')"
+    echo "  --distro-version  Version of the base distribution (e.g., '20.04', '22.04')"
+    echo "  --arch            RISC-V architecture (e.g., 'rv64imfc')"
+    echo "  --abi             RISC-V ABI (e.g., 'lp64f')"
+    echo "  --help            Show this help message"
+}
+
+# script that either downloads an existing riscv-gnu-toolchain build,
+# or, if it cannot find the specific one, builds it from source.
+FORCE_REBUILD="false"
+INSTALL_DEPS="false"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force) FORCE_REBUILD="$2"; shift 2;;
+        --repo) repo="$2"; shift 2 ;;
+        --install-dir) install_dir="$2"; shift 2 ;;
+        --base-distro) base_distro="$2"; shift 2 ;;
+        --distro-version) distro_version="$2"; shift 2 ;;
+        --arch) arch="$2"; shift 2 ;;
+        --abi) abi="$2"; shift 2 ;;
+        --install-deps) INSTALL_DEPS="$2"; shift 2 ;;
+        --help) help; exit 1 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# see if the one we want already exists as a release, in which case we can just pull it down
+if [ -z "$repo" ] || [ -z "$install_dir" ] || [ -z "$base_distro" ] || [ -z "$distro_version" ] || [ -z "$arch" ] || [ -z "$abi" ]; then
+    echo "Error: Missing required arguments."
+    help
+    exit 1
+fi
+
+if [ "$FORCE_REBUILD" = "true" ]; then
+    echo "Force rebuild specified, skipping download of existing release artifact."
+else
+    if [ "$INSTALL_DEPS" = "false" ]; then
+        echo "Skipping installation of dependencies for downloading existing release artifact as per user request."
+    else
+        echo "Installing dependencies for downloading existing release artifact."
+        case "$base_distro" in
+            ubuntu|debian)
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get update && apt-get install -y \
+                    curl \
+                    jq \
+                    xz-utils
+                ;;
+            *)
+                echo "Unsupported base distro: $base_distro"
+                exit 1
+                ;;
+        esac
+    fi
+
+    artifact_name="riscv64-elf-${base_distro}-${distro_version}-gcc-stripped.tar.xz"
+
+    downloadurl=$(curl -s https://api.github.com/repos/${repo}/releases/latest | jq -r '.assets[] | select(.name=="'"${artifact_name}"'") | .browser_download_url')
+
+    if [ -n "$downloadurl" ]; then
+        echo "Found existing release artifact at ${downloadurl}, downloading and extracting to ${install_dir}"
+        mkdir -p ${install_dir}
+        curl -L ${downloadurl} | tar --strip-components=1 -xJ -C ${install_dir}
+        exit 0
+    fi
+fi
+
+if [ "$INSTALL_DEPS" = "false" ]; then
+    echo "Skipping installation of dependencies for building riscv-gnu-toolchain as per user request."
+else
+    echo "Installing dependencies for building riscv-gnu-toolchain."
+    case "$base_distro" in
+        ubuntu|debian)
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update && apt-get install -y \
+                autoconf \
+                automake \
+                autotools-dev \
+                curl \
+                python3 \
+                python3-pip \
+                python3-tomli \
+                libmpc-dev \
+                libmpfr-dev \
+                libgmp-dev \
+                gawk \
+                build-essential \
+                bison \
+                flex \
+                texinfo \
+                gperf \
+                libtool \
+                patchutils \
+                bc \
+                zlib1g-dev \
+                libexpat-dev \
+                dos2unix \
+                ninja-build \
+                git \
+                cmake \
+                libglib2.0-dev \
+                libslirp-dev
+            ;;
+        *)
+            echo "Unsupported base distro: $base_distro"
+            exit 1
+            ;;
+    esac
+fi
+
+mkdir -p ${install_dir} && chmod 755 ${install_dir}
+
+tmpdir=$(mktemp -d)
+cd ${tmpdir}
+git clone https://github.com/${repo} riscv-gnu-toolchain
+cd riscv-gnu-toolchain
+./configure \
+    --prefix=${install_dir} \
+    --with-arch=${arch} \
+    --with-abi=${abi} \
+    --with-languages=c,c++ \
+    --with-cmodel=medany
+make -j$(nproc)
+cd /tmp
+rm -rf ${tmpdir}


### PR DESCRIPTION
The Dockerfile - which we plan to use in CI - currently rebuilds the entire aifoundry-org/riscv-gnu-toolchain (RGT), even if it is building the identical artifacts that RGT already publishes.

This PR creates a script `tools/get_rgt.sh` (innovative name! 😆) that does the following:

1. Find the latest release of RGT
2. Check its published artifacts
3. See if it has an artifact matches what we want
4. If it does, download and untar it; done
5. If it does not, build it

This should significantly speed up builds, unless we are building for a platform that does not exist in RGT releases.

In the `get_rgt.sh` script, ou can force a rebuild - ignore trying to download - with `--force true`, or try with `--force false` (default). This gets set in the dockerfile via `docker build --build-arg FORCE_REBUILD=true`.

Marking this as draft as I still am testing it, but it should be ready to go soon.