### PR TITLE
dockerfile, GH Actions verbose and hash string flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,11 @@ jobs:
     - name: build in docker
       uses: docker/build-push-action@v6
       with:
+        context: .  # this is necessary for .git to be available inside the container
         push: false
         file: docker/Dockerfile
         tags: et-platform:latest
         build-args: |
           BASE_DISTRO=${{ matrix.target.distro_name }}
           DISTRO_VERSION=${{ matrix.target.distro_version }}
+          VERBOSE=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN DEBUG=1 /get_toolchain.sh --force ${FORCE_REBUILD} --install-deps true --rep
 
 FROM ${BASE_DISTRO}:${DISTRO_VERSION} AS etplatform_builder
 ARG ET_INSTALL_DIR=/opt/et
+ARG VERBOSE
 
 # Copy the RISC-V GNU Toolchain from the previous stage
 COPY --from=toolchain_builder ${ET_INSTALL_DIR} ${ET_INSTALL_DIR}
@@ -82,7 +83,7 @@ RUN cmake \
 
 # Build the ET Platform (use ARG to allow override)
 ARG BUILD_JOBS=4
-RUN make -j${BUILD_JOBS}
+RUN make ${VERBOSE:+VERBOSE=1} -j${BUILD_JOBS}
 
 # Set the default working directory
 WORKDIR /workspace


### PR DESCRIPTION
We had two issues with the [previous build](https://github.com/aifoundry-org/et-platform/actions/runs/20267433977/job/58194126995)

1. It failed because it expected to run in a git repo, which didn't get carried through via the GitHub actions clone and on to docker build
2. It was hard to debug because we didn't run it with VERBOSE

This PR solves those as follows:

1. Creates build arg to the Dockerfile `GIT_HASH_STRING`. If set and non empty, it then passes it as a `-DGIT_HASH_STRING` to `cmake`, which then uses it
2. Creates build arg to the Dockerfile `VERBOSE`. If set and non empty, it then adds `VERBOSE=1` to the `make` command
3. Adds `VERBOSE=1` to the build args when running through GitHub actions
4. Adds `GIT_HASH_STRING` to the build args when running through GitHub actions 