### PR TITLE
Run CI on all PRs and pushes to master and main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,15 @@
 name: CI
 on:
-#- push    # we will enable this once we see a few good runs
-#- pull_request
-- workflow_dispatch
+  push:
+    branches:
+      - "master"
+      - "main"
+  pull_request:
+    branches:
+      - "master"
+      - "main"
+
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Also keep the option to run jobs manually, of course.

Once this is in place, we can look at adding tests beyond just building.

The last manual run was successful, see [this job](https://github.com/aifoundry-org/et-platform/actions/runs/20292966696/job/58280877736).