### PR TITLE
Added helper scripts for development within docker

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+set -x
+
+docker build -t et-platform -f docker/Dockerfile .

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+USER_ID=${USER_ID:-1000}
+GROUP_ID=${GROUP_ID:-1000}
+USER_NAME=${USER_NAME:-user}
+USER_NAME=${USER_NAME:-user}
+OPT=${ARGS:+-c $ARGS}
+
+COLLIDING_USER_NAME=$(id -nu "$USER_ID" 2>/dev/null)
+
+if [[ -n "$COLLIDING_USER_NAME" ]]; then
+  echo Removing colliding user "($COLLIDING_USER_NAME)"...
+  userdel "$COLLIDING_USER_NAME"
+fi
+
+echo Adding invoking user "($USER_NAME)"...
+groupadd -g "$GROUP_ID" "$USER_NAME"
+useradd -u "$USER_ID" -g "$GROUP_ID" -s /bin/bash "$USER_NAME"
+
+set -x
+exec su "$USER_NAME" $OPT

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+USER_NAME=$(id -un)
+
+set -x
+
+docker run -it \
+  -e USER_ID=$USER_ID \
+  -e GROUP_ID=$GROUP_ID \
+  -e USER_NAME=$USER_NAME \
+  -e ARGS="$*" \
+  --volume $HOME:$HOME \
+  --volume $PWD:$PWD \
+  --entrypoint $PWD/docker/entrypoint.sh \
+  --workdir $PWD \
+  et-platform:latest


### PR DESCRIPTION
Two helper scripts added for development within docker containers:

- docker/build.sh: builds the et-plaform:latest docker image using sensible defaults.

- docker/run.sh: launches et-plaform:latest on a docker container, also with sensible defaults.

The run.sh script clones the user invoking the script into the newly launched container. Then an optional command is executed in the container using the
credentials of the invoking user and the current
directory.

Should the invoking user not provide any command then an interactive shell is open.