### PR TITLE
sw-sysemu: For uart devices, support 1 and 2 byte accesses in addition to 4 bytes.

### DIFF
--- a/sw-sysemu/devices/uart.h
+++ b/sw-sysemu/devices/uart.h
@@ -27,19 +27,27 @@ struct Uart : public MemoryRegion {
 
     // Registers from DW_apb_uart.csr
     enum : size_type {
-        DW_APB_UART_RBR_THR = 0x00,
-        DW_APB_UART_LSR = 0x14,
+        DW_APB_UART_RBR_THR = 0x00,  // Receiver Buffer / Transmitter Holding
+        DW_APB_UART_IER     = 0x04,  // Interrupt Enable Register
+        DW_APB_UART_IIR     = 0x08,  // Interrupt Identification Register (read)
+        DW_APB_UART_FCR     = 0x08,  // FIFO Control Register (write)
+        DW_APB_UART_LCR     = 0x0C,  // Line Control Register
+        DW_APB_UART_MCR     = 0x10,  // Modem Control Register
+        DW_APB_UART_LSR     = 0x14,  // Line Status Register
+        DW_APB_UART_MSR     = 0x18,  // Modem Status Register
     };
 
     // LSR register fields
     enum : size_type {
-        DW_APB_UART_LSR_DR_SHIFT = 0,
-        DW_APB_UART_LSR_THRE_SHIFT = 5,
+        DW_APB_UART_LSR_DR_SHIFT = 0,    // Data Ready
+        DW_APB_UART_LSR_THRE_SHIFT = 5,  // Transmit Holding Register Empty
     };
 
     void read(const Agent&, size_type pos, size_type n, pointer result) override {
-        (void) n;
-        assert(n == 4);
+        // Support 1-byte, 2-byte, and 4-byte accesses (real hardware supports all sizes)
+        if (n != 1 && n != 2 && n != 4) {
+            throw std::runtime_error("UART: Unsupported access size");
+        }
 
         switch (pos) {
         case DW_APB_UART_RBR_THR: {
@@ -48,7 +56,7 @@ struct Uart : public MemoryRegion {
                 auto res = ::read(rx_fd, &data, 1);
                 (void)res;
             }
-           *reinterpret_cast<uint32_t*>(result) = data;
+            write_value_by_size(result, n, static_cast<uint32_t>(static_cast<uint8_t>(data)));
             break;
         }
         case DW_APB_UART_LSR: {
@@ -56,29 +64,59 @@ struct Uart : public MemoryRegion {
             if (rx_fd != -1 && fd_read_data_available(rx_fd)) {
                 dr = 1;
             }
-            *reinterpret_cast<uint32_t*>(result) =
-                (dr << DW_APB_UART_LSR_DR_SHIFT) |  // Data Ready in the RBR or the receiver FIFO
-                (0  << DW_APB_UART_LSR_THRE_SHIFT); // Transmit FIFO always empty
+            uint32_t lsr =
+                (dr << DW_APB_UART_LSR_DR_SHIFT) |   // Data Ready in the RBR or the receiver FIFO
+                (1  << DW_APB_UART_LSR_THRE_SHIFT);  // Transmit FIFO always empty (ready to accept data)
+            write_value_by_size(result, n, lsr);
             break;
         }
+        case DW_APB_UART_IER:
+        case DW_APB_UART_LCR:
+        case DW_APB_UART_MCR:
+            // Return stored/default values for control registers
+            write_value_by_size(result, n, 0);
+            break;
+        case DW_APB_UART_IIR:
+            // IIR bit 0 = 1 means no interrupt pending
+            write_value_by_size(result, n, 0x01);
+            break;
+        case DW_APB_UART_MSR:
+            // Modem status - indicate ready state
+            write_value_by_size(result, n, 0xF0);
+            break;
         default:
-            *reinterpret_cast<uint32_t*>(result) = 0;
+            // Unknown registers return 0
+            write_value_by_size(result, n, 0);
             break;
         }
     }
 
     void write(const Agent&, size_type pos, size_type n, const_pointer source) override {
-        (void) n;
-        assert(n == 4);
+        // Support 1-byte, 2-byte, and 4-byte accesses (real hardware supports all sizes)
+        if (n != 1 && n != 2 && n != 4) {
+            throw std::runtime_error("UART: Unsupported access size");
+        }
 
         switch (pos) {
-        case DW_APB_UART_RBR_THR:
-            if ((tx_fd != -1) && (::write(tx_fd, source, 1) < 0)) {
+        case DW_APB_UART_RBR_THR: {
+            // Extract the byte to write (lower 8 bits regardless of access size)
+            uint8_t byte_to_write = static_cast<uint8_t>(read_value_by_size(source, n));
+
+            if ((tx_fd != -1) && (::write(tx_fd, &byte_to_write, 1) < 0)) {
                 auto error = std::error_code(errno, std::system_category());
                 throw std::system_error(error, "bemu::Uart::write()");
             }
             break;
+        }
+        case DW_APB_UART_IER:
+        case DW_APB_UART_FCR:
+        case DW_APB_UART_LCR:
+        case DW_APB_UART_MCR:
+            // Accept writes to control registers but don't implement functionality
+            // (polling mode doesn't need these to work)
+            break;
         default:
+            // Silently ignore writes to other/unknown registers
             break;
         }
     }
@@ -108,6 +146,35 @@ private:
             return false;
         }
         return FD_ISSET(fd, &rfds);
+    }
+
+    // Helper function to write a value to result buffer based on access size
+    static void write_value_by_size(pointer dest, size_type n, uint32_t value) {
+        switch (n) {
+        case 1:
+            *reinterpret_cast<uint8_t*>(dest) = static_cast<uint8_t>(value);
+            break;
+        case 2:
+            *reinterpret_cast<uint16_t*>(dest) = static_cast<uint16_t>(value);
+            break;
+        case 4:
+            *reinterpret_cast<uint32_t*>(dest) = value;
+            break;
+        }
+    }
+
+    // Helper function to read a value from source buffer based on access size
+    static uint32_t read_value_by_size(const_pointer src, size_type n) {
+        switch (n) {
+        case 1:
+            return *reinterpret_cast<const uint8_t*>(src);
+        case 2:
+            return *reinterpret_cast<const uint16_t*>(src);
+        case 4:
+            return *reinterpret_cast<const uint32_t*>(src);
+        default:
+            return 0;
+        }
     }
 };
 


### PR DESCRIPTION
It is expected that real devices can support any arbitrary byte access.

Zephyr's ns16550 uart driver defaults to asking for 1 and 2 byte reads rather
than 4 bytes which causes failures.

(This patch was devised by Claude Code.)
