### PR TITLE
Fix build faiure by default

### DIFF
--- a/sw-sysemu/mmu.cpp
+++ b/sw-sysemu/mmu.cpp
@@ -31,7 +31,7 @@ namespace bemu {
 // Exceptions
 
 
-inline Privilege effective_execution_mode(const Hart& cpu, mem_access_type macc)
+Privilege effective_execution_mode(const Hart& cpu, mem_access_type macc)
 {
     // Read mstatus
     const uint64_t  mstatus = cpu.mstatus;


### PR DESCRIPTION
`bemu::effective_execution_mode` symbol is missing from the built library leading to the following linking error in a clean build:

```
[100%] Linking CXX executable sys_emu
/usr/bin/ld: libsw-sysemu.a(pma.cpp.o): in function `bemu::pma_check_data_access(bemu::Hart const&, unsigned long, unsigned long, unsigned long, bemu::mem_access_type, std::bitset<8ul>, bemu::cacheop_type)':
/home/marty/Documents/et-platform/sw-sysemu/pma_et.cpp:183: undefined reference to `bemu::effective_execution_mode(bemu::Hart const&, bemu::mem_access_type)'
/usr/bin/ld: /home/marty/Documents/et-platform/sw-sysemu/pma_et.cpp:267: undefined reference to `bemu::effective_execution_mode(bemu::Hart const&, bemu::mem_access_type)'
/usr/bin/ld: /home/marty/Documents/et-platform/sw-sysemu/pma_et.cpp:209: undefined reference to `bemu::effective_execution_mode(bemu::Hart const&, bemu::mem_access_type)'
/usr/bin/ld: /home/marty/Documents/et-platform/sw-sysemu/pma_et.cpp:197: undefined reference to `bemu::effective_execution_mode(bemu::Hart const&, bemu::mem_access_type)'
/usr/bin/ld: /home/marty/Documents/et-platform/sw-sysemu/pma_et.cpp:292: undefined reference to `bemu::effective_execution_mode(bemu::Hart const&, bemu::mem_access_type)'
/usr/bin/ld: libsw-sysemu.a(pma.cpp.o):/home/marty/Documents/et-platform/sw-sysemu/pma_et.cpp:274: more undefined references to `bemu::effective_execution_mode(bemu::Hart const&, bemu::mem_access_type)' follow
collect2: error: ld returned 1 exit status
```

This patch adds back the symbol and makes clean build successful again.