### PR TITLE
[sw-sysemu] Fix second thread starting

### DIFF
--- a/sw-sysemu/sys_emu/sys_emu.cpp
+++ b/sw-sysemu/sys_emu/sys_emu.cpp
@@ -410,7 +410,9 @@ sys_emu::sys_emu(const sys_emu_cmd_options &cmd_options, api_communicate *api_co
     chip.cold_reset();
 
 
-    // Configure the simulation parameters
+#if EMU_ETSOC1
+    // Configure the simulation parameters (ET-SoC-1 only)
+    // Erbium honors ESR defaults set during cold_reset()
     for (unsigned shire = 0; shire < EMU_NUM_MINION_SHIRES; ++shire) {
         if (((cmd_options.shires_en >> shire) & 1) == 0) {
             chip.config_simulated_harts(shire, 0, false, false);
@@ -433,6 +435,7 @@ sys_emu::sys_emu(const sys_emu_cmd_options &cmd_options, api_communicate *api_co
                                     false, !cmd_options.sp_dis);
     }
 #endif
+#endif // EMU_ETSOC1
 
     // Reset the warm-reset part of the system
     for (unsigned shire = 0; shire < EMU_NUM_SHIRES; ++shire) {

--- a/sw-sysemu/sys_emu/sys_emu_parse_args.cpp
+++ b/sw-sysemu/sys_emu/sys_emu_parse_args.cpp
@@ -36,11 +36,17 @@ static const char * help_msg =
 "                                cacheops  Cache operations with undefined behavior\n"
 "                                debug     Undefined behavior while in debug mode\n"
 "                                other     Other warnings\n"
+#if EMU_ETSOC1
 "     -minions <mask>          A mask of Minions that should be enabled in each Shire (default: 1 Minion/Shire)\n"
 "     -shires <mask>           A mask of Shires that should be enabled. (default: 1 Shire)\n"
+#endif
+#if EMU_ETSOC1
 "     -single_thread           Disable 2nd Minion thread\n"
+#endif
 #ifndef SDK_RELEASE
+#if EMU_ETSOC1
 "     -mins_dis                Minions (not including SP) start disabled\n"
+#endif
 #if EMU_HAS_SVCPROC
 "     -sp_dis                  SP starts disabled\n"
 #endif // EMU_HAS_SVCPROC
@@ -168,12 +174,18 @@ sys_emu::parse_command_line_arguments(int argc, char* argv[])
         {"ltrigger_start",         required_argument, nullptr, 0},
         {"ltrigger_stop",          required_argument, nullptr, 0},
         {"Werror",                 optional_argument, nullptr, 0},
+#if EMU_ETSOC1
         {"minions",                required_argument, nullptr, 0},
         {"shires",                 required_argument, nullptr, 0},
         {"master_min",             no_argument,       nullptr, 0}, // deprecated, use -shires <mask> to enable Master Shire and SP
+#endif
+#if EMU_ETSOC1
         {"single_thread",          no_argument,       nullptr, 0},
+#endif
 #ifndef SDK_RELEASE
+#if EMU_ETSOC1
         {"mins_dis",               no_argument,       nullptr, 0},
+#endif
 #if EMU_HAS_SVCPROC
         {"sp_dis",                 no_argument,       nullptr, 0},
 #endif
@@ -347,6 +359,7 @@ sys_emu::parse_command_line_arguments(int argc, char* argv[])
             }
             cmd_options.warning.make_error(category);
         }
+#if EMU_ETSOC1
         else if (!strcmp(name, "minions"))
         {
             sscanf(optarg, "%" PRIx64, &cmd_options.minions_en);
@@ -359,18 +372,25 @@ sys_emu::parse_command_line_arguments(int argc, char* argv[])
         {
             SE_WARN("Ignoring deprecated option '-master_min'");
         }
+#endif
+#if EMU_ETSOC1
         else if (!strcmp(name, "single_thread"))
         {
             cmd_options.second_thread = false;
         }
+#endif
+#if EMU_ETSOC1
         else if (!strcmp(name, "mins_dis"))
         {
             cmd_options.mins_dis = true;
         }
+#endif
+#if EMU_HAS_SVCPROC
         else if (!strcmp(name, "sp_dis"))
         {
             cmd_options.sp_dis = true;
         }
+#endif
         else if (!strcmp(name, "reset_pc"))
         {
             sscanf(optarg, "%" PRIx64, &cmd_options.reset_pc);

--- a/sw-sysemu/tests/erbium/Makefile
+++ b/sw-sysemu/tests/erbium/Makefile
@@ -6,7 +6,6 @@ VERBOSE ?= 0
 BUILD_DIR := build
 EMU       := ../../build/erbium_emu
 RISCV     ?= /opt/et/bin
-EMU_ARGS  ?= -minions 0xff -mins_dis
 
 # Verbosity
 VERBOSE_0 := @
@@ -62,7 +61,7 @@ run: $(tests_elf)
 	@npass=0; nfail=0; \
 	for test in $(tests); do \
 		echo "+ running $$test"; \
-		$(EMU) -l $(EMU_ARGS) -elf_load $(BUILD_DIR)/$$test.elf > $(BUILD_DIR)/$$test.out 2>&1; \
+		$(EMU) -l -elf_load $(BUILD_DIR)/$$test.elf > $(BUILD_DIR)/$$test.out 2>&1; \
 		if grep -q "Signal end test with FAIL" $(BUILD_DIR)/$$test.out; then \
 			echo "  FAIL"; \
 			nfail=$$((nfail + 1)); \
@@ -85,7 +84,7 @@ run: $(tests_elf)
 # Run individual test
 run/%: $(BUILD_DIR)/%.elf
 	@echo "+ running $*"
-	@$(EMU) -l $(EMU_ARGS) -elf_load $< > $(BUILD_DIR)/$*.out 2>&1; \
+	@$(EMU) -l -elf_load $< > $(BUILD_DIR)/$*.out 2>&1; \
 	if grep -q "Signal end test with FAIL" $(BUILD_DIR)/$*.out; then \
 		echo "  FAIL"; exit 1; \
 	elif grep -q "Signal end test with PASS" $(BUILD_DIR)/$*.out; then \


### PR DESCRIPTION
This is a potential solution to #60.

The root cause is that sysemu overwrites `threadx_disabled` ESRs with values from command line arguments.
The command line arguments have defaults, so even when not provided they overwrite ESRs (with argument defaults).
ET-SoC-1 version has all threads disabled in ESRs, so it's a reasonable behavior.

Suggested and implemented solution: get rid of all minion/thread control cli arguments and honor ESR defaults.
Removed arguments:
- `shires <mask>` - not applicable to Erbium
- `single_thread` - disables second thread on *all* minions (could be useful is we change semantics, because currently when omitted it *enables* second thread on *all* minions)
- `mins_dis` - not applicable, disables all minions  (to run just service processor)
- `sp_dis` - not applicable, Erbium has no service processor
- `minions <mask>` - enables only selected minions. Could be useful, currently defaults to enabling only the first minion when omitted.

Eventually erbium_emu should probably get its own options and system initializer.