### PR TITLE
[sw-sysemu] RVTimer fixes

### DIFF
--- a/sw-sysemu/devices/rvtimer.h
+++ b/sw-sysemu/devices/rvtimer.h
@@ -23,6 +23,9 @@ struct RVTimer
 
     void reset() {
         mtime = 0;
+        prescaler = 0;
+        prescaler_threshold = 20; // generate 10MHz from 200MHz
+        ref_clock_mux = 0; // unused, only stores value
         mtimecmp = std::numeric_limits<uint64_t>::max();
         interrupt = false;
     }
@@ -57,6 +60,15 @@ struct RVTimer
         }
     }
 
+    uint32_t read_time_config() const {
+        return (prescaler_threshold & 0x7f) | (ref_clock_mux << 7);
+    }
+
+    void write_time_config(const Agent&, uint32_t val) {
+        prescaler_threshold = val & 0x7f;
+        ref_clock_mux = (val >> 7) & 0x1;
+    }
+
     void clock_tick(const Agent& agent)
     {
         if (++mtime >= mtimecmp) {
@@ -71,9 +83,20 @@ struct RVTimer
         }
     }
 
+    void prescaler_tick(const Agent& agent)
+    {
+        if (++prescaler >= prescaler_threshold) {
+            prescaler = 0;
+            clock_tick(agent);
+        }
+    }
+
 private:
     uint64_t mtime;
     uint64_t mtimecmp;
+    uint32_t prescaler;
+    uint32_t prescaler_threshold;
+    uint32_t ref_clock_mux;
     bool interrupt;
 };
 

--- a/sw-sysemu/esrs_er.cpp
+++ b/sw-sysemu/esrs_er.cpp
@@ -204,7 +204,6 @@ void shire_other_esrs_t::cold_reset(unsigned shireid)
     mtime_local_target = 0;
     clk_gate_ctrl = 0;
     debug_clk_gate_ctrl = 0;
-    // time_config = 0x28;
     // sm_config = 0;
 }
 
@@ -363,8 +362,7 @@ uint64_t System::esr_read(const Agent& agent, uint64_t addr)
         case ESR_MTIMECMP:
             return memory.rvtimer_read_mtimecmp();
         case ESR_TIME_CONFIG:
-            // TODO: undefined
-            return 0;
+            return memory.rvtimer_read_time_config();
         case ESR_MTIME_LOCAL_TARGET:
             return shire_other_esrs[shire].mtime_local_target;
         case ESR_THREAD0_DISABLE:
@@ -640,10 +638,7 @@ void System::esr_write(const Agent& agent, uint64_t addr, uint64_t value)
             memory.rvtimer_write_mtimecmp(agent, value);
             return;
         case ESR_TIME_CONFIG:
-            // TODO: undefined
-            // shire_other_esrs[shire].time_config = uint16_t(value & 0x3ff);
-            // LOG_AGENT(DEBUG, agent, "S%u:time_config = 0x%" PRIx16,
-            //           shireid(shire), shire_other_esrs[shire].time_config);
+            memory.rvtimer_write_time_config(agent, value);
             return;
         case ESR_MTIME_LOCAL_TARGET:
             shire_other_esrs[shire].mtime_local_target = uint16_t(value & 0xFFFF);

--- a/sw-sysemu/memory/erbium/main_memory.cpp
+++ b/sw-sysemu/memory/erbium/main_memory.cpp
@@ -46,8 +46,15 @@ uint64_t MainMemory::rvtimer_read_mtimecmp() const {
     return rvtimer().read_mtimecmp();
 }
 
-void MainMemory::rvtimer_clock_tick(const Agent& agent) {
-    rvtimer().clock_tick(agent);
+uint64_t MainMemory::rvtimer_read_time_config() const {
+    return rvtimer().read_time_config();
+}
+
+void MainMemory::rvtimer_clock_tick(const Agent& agent, uint64_t cycle) {
+    // cycle at 200MHz
+    if ((cycle % 5) == 0) {
+        rvtimer().prescaler_tick(agent);
+    }
 }
 
 void MainMemory::rvtimer_write_mtime(const Agent& agent, uint64_t value) {
@@ -56,6 +63,10 @@ void MainMemory::rvtimer_write_mtime(const Agent& agent, uint64_t value) {
 
 void MainMemory::rvtimer_write_mtimecmp(const Agent& agent, uint64_t value) {
     rvtimer().write_mtimecmp(agent, value);
+}
+
+void MainMemory::rvtimer_write_time_config(const Agent& agent, uint64_t value) {
+    rvtimer().write_time_config(agent, value);
 }
 
 void MainMemory::rvtimer_reset() {

--- a/sw-sysemu/memory/erbium/main_memory.h
+++ b/sw-sysemu/memory/erbium/main_memory.h
@@ -120,9 +120,11 @@ public:
     bool rvtimer_is_active() const;
     uint64_t rvtimer_read_mtime() const;
     uint64_t rvtimer_read_mtimecmp() const;
-    void rvtimer_clock_tick(const Agent&);
+    uint64_t rvtimer_read_time_config() const;
+    void rvtimer_clock_tick(const Agent&, uint64_t cycle);
     void rvtimer_write_mtime(const Agent&, uint64_t value);
     void rvtimer_write_mtimecmp(const Agent&, uint64_t value);
+    void rvtimer_write_time_config(const Agent&, uint64_t value);
     void rvtimer_reset();
 
 protected:

--- a/sw-sysemu/system.h
+++ b/sw-sysemu/system.h
@@ -511,6 +511,10 @@ inline void System::tick_peripherals(uint64_t cycle)
     memory.wdt_clock_tick(noagent, cycle);
 #endif
 
+#if EMU_HAS_RVTIMER
+    memory.rvtimer_clock_tick(noagent, cycle);
+#endif
+
     // cycle at 1GHz, timer clock at 10MHz
     if ((cycle % 100) == 0) {
 
@@ -519,9 +523,6 @@ inline void System::tick_peripherals(uint64_t cycle)
 #endif
 #if EMU_HAS_SPIO
         memory.spio_rvtimer_clock_tick(noagent);
-#endif
-#if EMU_HAS_RVTIMER
-        memory.rvtimer_clock_tick(noagent);
 #endif
 
 #if EMU_HAS_PU


### PR DESCRIPTION
Fix `mtimecmp` write logic (set absolute value rather than relative to the current `mtime`). Bug was introduced in https://github.com/aifoundry-org/et-platform/commit/a9fbdd0e15e8e4ba66b3b10ead3d119d76208631.

Add timer prescaler and `time_config` register to control it.

`ref_clock_mux` field of `time_config` register doesn't do anything on emulator.

I not too happy with `memory` re-exposing so many `rvtimer` functions, but decided to keep it as is for now.