### PR TITLE
[sw-sysemu] Set Erbium mtime_local_target reset value to 0xFFFF

### DIFF
--- a/sw-sysemu/esrs_er.cpp
+++ b/sw-sysemu/esrs_er.cpp
@@ -201,7 +201,7 @@ void shire_other_esrs_t::cold_reset(unsigned shireid)
     minion_feature = 0x01;
     thread0_disable = 0xFE; // Only start minion 0 hart 0.
     thread1_disable = 0xFF;
-    mtime_local_target = 0;
+    mtime_local_target = 0xFFFF;
     clk_gate_ctrl = 0;
     debug_clk_gate_ctrl = 0;
     // sm_config = 0;


### PR DESCRIPTION
Erbium hardware defaults mtime_local_target to 0xFFFF, directing the timer interrupt to all harts. The emulator had 0x0, which meant no hart received the timer interrupt unless software explicitly wrote the register first.

Fixes #65