### PR TITLE
[sw-sysemu] show erbium_emu in help output for Erbium build

### DIFF
--- a/sw-sysemu/sys_emu/sys_emu_parse_args.cpp
+++ b/sw-sysemu/sys_emu/sys_emu_parse_args.cpp
@@ -9,8 +9,13 @@
 #include "sys_emu.h"
 
 static const char * help_msg =
+#if EMU_ERBIUM
+"\n Erbium System Emulator\n\n"
+"     erbium_emu [options]\n\n"
+#elif EMU_ETSOC1
 "\n ET System Emulator\n\n"
 "     sys_emu [options]\n\n"
+#endif
 " Where options are:\n"
 #ifndef SDK_RELEASE
 "     -elf_load <path>         Path to an ELF file to load. Can be used multiple times.\n"


### PR DESCRIPTION
The help text was hardcoded to show "sys_emu" regardless of the build target. Use the correct executable name per platform.

Very short PR but didn't fit any of the others.