### PR TITLE
Fixing a bug in reverse lookup of ID to enum

### DIFF
--- a/firmware-flash-tool/src/parse_template_file.c
+++ b/firmware-flash-tool/src/parse_template_file.c
@@ -69,8 +69,14 @@ ESPERANTO_FLASH_REGION_ID_t region_name_to_id(const char * name) {
 }
 
 const char * region_id_to_name(ESPERANTO_FLASH_REGION_ID_t id) {
-    if (ESPERANTO_FLASH_REGION_ID_INVALID <= id && id < ESPERANTO_FLASH_REGION_ID_AFTER_LAST_SUPPORTED_VALUE) {
-        return regions_info[id - 1].name;
+    uint32_t n;
+
+    if (ESPERANTO_FLASH_REGION_ID_INVALID < id && id < ESPERANTO_FLASH_REGION_ID_AFTER_LAST_SUPPORTED_VALUE) {
+        for (n = 0; n < regions_count; n++) {
+            if (regions_info[n].id == id) {
+                return regions_info[n].name;
+            }
+        }
     }
     return NULL;
 }


### PR DESCRIPTION
When I was trying to replace SP_BL2 in the image I've noticed that SP_BL2 resolves to numeric ID 0x9 in the enum at firmware-flash-tool/include/esperanto_flash_image.h:18. The replace path then matches regions by numeric region_id, not by the printed string, at firmware-flash-tool/src/esperanto_flash_image_replace.c:90.

The bad output comes from region_id_to_name(), which assumes the lookup table is in enum order, but the table has PMIC_FW_S0 and PMIC_FW_S1 inserted before SP_BL1/SP_BL2 at firmware-flash-tool/src/parse_template_file.c:31. So ID 0x9 gets mislabeled as PMIC_FW_S1 when printed at firmware-flash-tool/src/parse_template_file.c:71.

Arguably this can be maintained at the cost of precise ordering, but it seems that a quick scan of the table is a better option

