### PR TITLE
Fix compiler errors

### DIFF
--- a/gp-sdk/device/riscv_helpers.cmake
+++ b/gp-sdk/device/riscv_helpers.cmake
@@ -82,6 +82,7 @@ function(add_riscv_executable TARGET_NAME)
     # baremetal & startup
     -fno-exceptions -fno-rtti -fno-unwind-tables
     -fno-use-cxa-atexit -fno-threadsafe-statics -ffreestanding
+    -Wno-template-body
   )
   target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
 

--- a/sw-sysemu/devices/DW_apb_timers.h
+++ b/sw-sysemu/devices/DW_apb_timers.h
@@ -83,7 +83,7 @@ struct DW_apb_timers : public MemoryRegion {
         if (n != 4)
             throw memory_error(first() + pos);
 
-        if (pos < (NUM_TIMERS * REG_STRIDE)) {
+        if (pos < (static_cast<size_type>(NUM_TIMERS) * static_cast<size_type>(REG_STRIDE))) {
             size_type timer = pos / REG_STRIDE;
             size_type timer_pos = pos % REG_STRIDE;
 
@@ -144,7 +144,7 @@ struct DW_apb_timers : public MemoryRegion {
         if (n != 4)
             throw memory_error(first() + pos);
 
-        if (pos >= (NUM_TIMERS * REG_STRIDE))
+        if (pos >= (static_cast<size_type>(NUM_TIMERS) * static_cast<size_type>(REG_STRIDE)))
             return;
 
         size_type timer = pos / REG_STRIDE;

--- a/sw-sysemu/memory/etsoc1/main_memory.cpp
+++ b/sw-sysemu/memory/etsoc1/main_memory.cpp
@@ -263,32 +263,32 @@ void MainMemory::spio_apb_timers_clock_tick(System& chip)
 
 void MainMemory::pc_mm_mailbox_read(const Agent& agent, addr_type offset, size_type n, void* result)
 {
-    read(agent, pu_mbox_base + MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_mm_pos + offset, n, result);
+    read(agent, pu_mbox_base + static_cast<unsigned long long>(MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_mm_pos) + offset, n, result);
 }
 
 
 void MainMemory::pc_mm_mailbox_write(const Agent& agent, addr_type offset, size_type n, const void* source)
 {
-    write(agent, pu_mbox_base + MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_mm_pos + offset, n, source);
+    write(agent, pu_mbox_base + static_cast<unsigned long long>(MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_mm_pos) + offset, n, source);
 }
 
 
 void MainMemory::pc_sp_mailbox_read(const Agent& agent, addr_type offset, size_type n, void* result)
 {
-    read(agent, pu_mbox_base + MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_sp_pos + offset, n, result);
+    read(agent, pu_mbox_base + static_cast<unsigned long long>(MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_sp_pos) + offset, n, result);
 }
 
 
 void MainMemory::pc_sp_mailbox_write(const Agent& agent, addr_type offset, size_type n, const void* source)
 {
-    write(agent, pu_mbox_base + MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_sp_pos + offset, n, source);
+    write(agent, pu_mbox_base + static_cast<unsigned long long>(MailboxRegion<pu_mbox_base, 512_MiB>::pu_mbox_pc_sp_pos) + offset, n, source);
 }
 
 
 void MainMemory::pu_trg_pcie_mmm_int_inc(const Agent& agent)
 {
     uint32_t trigger = 1;
-    write(agent, pu_mbox_base + bemu::MailboxRegion<pu_mbox_base, 512_MiB>::pu_trg_pcie_pos + bemu::MMM_INT_INC,
+    write(agent, pu_mbox_base + static_cast<unsigned long long>(bemu::MailboxRegion<pu_mbox_base, 512_MiB>::pu_trg_pcie_pos) + bemu::MMM_INT_INC,
           sizeof(trigger), reinterpret_cast<bemu::MemoryRegion::const_pointer>(&trigger));
 }
 
@@ -296,7 +296,7 @@ void MainMemory::pu_trg_pcie_mmm_int_inc(const Agent& agent)
 void MainMemory::pu_trg_pcie_ipi_trigger(const Agent& agent)
 {
     uint32_t trigger = 1;
-    write(agent, pu_mbox_base + bemu::MailboxRegion<pu_mbox_base, 512_MiB>::pu_trg_pcie_pos + bemu::IPI_TRIGGER,
+    write(agent, pu_mbox_base + static_cast<unsigned long long>(bemu::MailboxRegion<pu_mbox_base, 512_MiB>::pu_trg_pcie_pos) + bemu::IPI_TRIGGER,
          sizeof(trigger), reinterpret_cast<bemu::MemoryRegion::const_pointer>(&trigger));
 }
 

--- a/sw-sysemu/sw-sysemu/SysEmuImp.cpp
+++ b/sw-sysemu/sw-sysemu/SysEmuImp.cpp
@@ -215,7 +215,7 @@ void SysEmuImp::process() {
 void SysEmuImp::mmioRead(uint64_t address, size_t size, std::byte* dst) {
   resume();
   std::promise<void> p;
-  auto request = [=, &p]() {
+  auto request = [=, this, &p]() {
     SE_LOG(INFO) << "Device memory read at: " << std::hex << address << " size: " << size << " host dst: " << dst;
     auto pci_addr = address;
     uint64_t host_access_offset = 0;
@@ -260,7 +260,7 @@ void SysEmuImp::mmioRead(uint64_t address, size_t size, std::byte* dst) {
 void SysEmuImp::mmioWrite(uint64_t address, size_t size, const std::byte* src) {
   resume();
   std::promise<void> p;
-  auto request = [=, &p]() {
+  auto request = [=, this, &p]() {
     SE_LOG(INFO) << "Device memory write at: " << std::hex << address << " size: " << size << " host src: " << src;
     auto pci_addr = address;
     uint64_t host_access_offset = 0;
@@ -300,7 +300,7 @@ void SysEmuImp::mmioWrite(uint64_t address, size_t size, const std::byte* src) {
 
 void SysEmuImp::raiseDevicePuPlicPcieMessageInterrupt() {
   resume();
-  auto request = [=]() {
+  auto request = [=, this]() {
     SE_LOG(INFO) << "raiseDevicePuPlicPcieMessageInterrupt";
     LOG_AGENT(INFO, agent_, "raise_device_interrupt(type = %s)", "PU");
     chip_->memory.pu_trg_pcie_mmm_int_inc(agent_);
@@ -333,7 +333,7 @@ bool SysEmuImp::raise_host_interrupt(uint32_t bitmap) {
 
 void SysEmuImp::raiseDeviceSpioPlicPcieMessageInterrupt() {
   resume();
-  auto request = [=]() {
+  auto request = [=, this]() {
     SE_LOG(INFO) << "raiseDeviceSpioPlicPcieMessageInterrupt";
     LOG_AGENT(INFO, agent_, "raise_device_interrupt(type = %s)", "SP");
     chip_->memory.pu_trg_pcie_ipi_trigger(agent_);
@@ -372,7 +372,7 @@ void SysEmuImp::notify_iatu_ctrl_2_reg_write(int pcie_id, uint32_t iatu, uint32_
 
 SysEmuImp::~SysEmuImp() {
   std::promise<void> p;
-  auto request = [=, &p]() {
+  auto request = [=, this, &p]() {
     try {
       chip_->set_emu_done(true);
       p.set_value();


### PR DESCRIPTION
When using the new version of riscv-gnu-toolchain, available in [this branch](https://github.com/aifoundry-org/riscv-gnu-toolchain/pull/9), specific compiler errors are thrown.

This fixes these allowing for the build of the et-platform via `cd build && make`.