### PR TITLE
runtime: allocate unique event IDs across wraparound

### DIFF
--- a/esperanto-tools-libs/src/EventManager.cpp
+++ b/esperanto-tools-libs/src/EventManager.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <condition_variable>
 #include <easy/profiler.h>
+#include <limits>
 #include <mutex>
 #include <thread>
 
@@ -29,10 +30,24 @@ void EventManager::addOnDispatchCallback(OnDispatchCallback callback) {
 
 EventId EventManager::getNextId() {
   std::lock_guard lock(mutex_);
-  auto res = EventId{nextEventId_++};
-  onflyEvents_.emplace(res);
-  RT_VLOG(LOW) << "Last event id: " << static_cast<int>(res);
-  return res;
+  using EventIdValue = std::underlying_type_t<EventId>;
+  constexpr auto kEventIdCount = static_cast<size_t>(std::numeric_limits<EventIdValue>::max()) + 1;
+
+  // EventId is a uint16_t and long-running inference processes legitimately
+  // wrap the counter. Never return an ID that is still in flight: emplace()
+  // used to fail silently here, so the newer command stole the older command's
+  // completion and the second response was reported as an unknown event.
+  for (size_t attempt = 0; attempt < kEventIdCount; ++attempt) {
+    auto res = EventId{nextEventId_++};
+    if (onflyEvents_.find(res) != onflyEvents_.end() || blockedThreads_.find(res) != blockedThreads_.end()) {
+      continue;
+    }
+    onflyEvents_.emplace(res);
+    RT_VLOG(LOW) << "Last event id: " << static_cast<int>(res);
+    return res;
+  }
+
+  throw Exception("No free runtime event IDs; synchronize the stream before submitting more commands");
 }
 
 void EventManager::dispatch(EventId event) {

--- a/esperanto-tools-libs/src/RuntimeImp.cpp
+++ b/esperanto-tools-libs/src/RuntimeImp.cpp
@@ -869,8 +869,16 @@ void RuntimeImp::dispatch(EventId event) {
   evt.setEvent(event);
   getProfiler()->record(evt);
   streamManager_.removeEvent(event);
+  // Keep the ID in flight until observers have consumed the completion. This
+  // prevents a wrapped ID from being reused between EventManager::dispatch()
+  // and the server worker forwarding the old completion to its client.
+  try {
+    notify(event);
+  } catch (...) {
+    eventManager_.dispatch(event);
+    throw;
+  }
   eventManager_.dispatch(event);
-  notify(event);
 }
 
 void RuntimeImp::checkDevice(DeviceId device) {

--- a/esperanto-tools-libs/tests/unit-tests/test_event_manager.cpp
+++ b/esperanto-tools-libs/tests/unit-tests/test_event_manager.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <functional>
 #include <gtest/gtest.h>
+#include <limits>
 #include <thread>
 
 #pragma GCC diagnostic push
@@ -104,6 +105,37 @@ TEST_F(EventManagerF, severalEvents) {
   for (auto i = 0U; i < 100; ++i) {
     EXPECT_TRUE(em_.isDispatched(events[i]));
   }
+}
+
+TEST_F(EventManagerF, wrapSkipsEventIdsStillInFlight) {
+  using EventIdValue = std::underlying_type_t<EventId>;
+  constexpr auto maxId = std::numeric_limits<EventIdValue>::max();
+
+  em_.nextEventId_ = maxId;
+  auto atMax = em_.getNextId();
+  auto atZero = em_.getNextId();
+  EXPECT_EQ(static_cast<EventIdValue>(atMax), maxId);
+  EXPECT_EQ(static_cast<EventIdValue>(atZero), 0);
+
+  em_.nextEventId_ = maxId;
+  auto skippedToOne = em_.getNextId();
+  EXPECT_EQ(static_cast<EventIdValue>(skippedToOne), 1);
+
+  em_.dispatch(atMax);
+  em_.dispatch(atZero);
+  em_.dispatch(skippedToOne);
+}
+
+TEST_F(EventManagerF, exhaustionFailsInsteadOfReturningDuplicateId) {
+  using EventIdValue = std::underlying_type_t<EventId>;
+  constexpr auto eventIdCount =
+    static_cast<size_t>(std::numeric_limits<EventIdValue>::max()) + 1;
+
+  for (size_t i = 0; i < eventIdCount; ++i) {
+    em_.onflyEvents_.emplace(EventId{static_cast<EventIdValue>(i)});
+  }
+  EXPECT_THROW(em_.getNextId(), Exception);
+  em_.onflyEvents_.clear();
 }
 
 TEST_F(EventManagerF, blockingThreads) {


### PR DESCRIPTION
## Problem

`EventId` is a 16-bit value. `EventManager::getNextId()` incremented through wraparound and ignored whether `std::set::emplace()` actually inserted the ID. If an older command with that ID was still in flight, the newer command reused it; the first completion erased the shared entry and the second produced `Couldn't dispatch event: 65535`. Long ET inference runs reproduced this and could leave the device unhealthy.

## Fix

- scan for a free ID at wraparound and never reuse an in-flight or still-blocked ID
- fail before submitting a duplicate command if all 65,536 IDs are concurrently occupied
- retain the ID until runtime observers consume the completion
- add wraparound, collision, and exhaustion regression tests

## Validation

- `git diff --check`
- focused tests are included; full container build/CI is pending on this draft

Paired host/CI containment is being prepared in aifoundry-org/hf-hackathon#117.